### PR TITLE
Added `maintenance_device` method to devices.py

### DIFF
--- a/src/librenms_handler/devices/devices.py
+++ b/src/librenms_handler/devices/devices.py
@@ -655,3 +655,23 @@ class Devices(LibreNMS):  # pylint: disable=R0904
             headers=self.headers,
             verify=self.verify,
         )
+    def maintenance_device(self, device: str, notes: str, duration: str):
+        """
+        Set a device into maintenance mode.
+
+        :param notes: Some description for the Maintenance
+        :param duration: Duration of Maintenance in format H:m
+        """
+        data = dict(
+            {
+                "notes": notes,
+                "duration": duration
+            }
+        )
+        return post(
+            f"{self.url}/{device}/maintenance",
+            json=data,
+            headers=self.headers,
+            verify=self.verify,
+        )
+ 


### PR DESCRIPTION
Added `maintenance_device` method to correspond with this API call:

https://docs.librenms.org/API/Devices/#maintenance_device

Tested and functions as expected. 

Kept duration as a string to keep the "H:m" formatting consistent. Initially thought about making duration an integer in minutes, then did math to convert, but keeping string seems to be the best approach here since the API appears to be looking for a string.